### PR TITLE
feat: go 1.22 and slog migration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        go: ['1.19', '1.20', '1.21']
+        go: ['1.21', '1.22']
     name: Go ${{ matrix.go }} test
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -19,10 +19,9 @@ Versions that also build are marked with :warning:.
 
 | Version | Supported          |
 |---------|--------------------|
-| <1.19   | :x:                |
-| 1.19    | :warning:          |
-| 1.20    | :white_check_mark: |
+| <1.21   | :x:                |
 | 1.21    | :white_check_mark: |
+| 1.22    | :white_check_mark: |
 
 ## License
 

--- a/attributes.go
+++ b/attributes.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 // StringValuer returns a Valuer that
@@ -12,8 +12,6 @@ import (
 // method, even in json ouput mode.
 // By wrapping the type we defer String
 // being called to the point we actually log.
-//
-// EXPERIMENTAL: Will change to log/slog import after we drop support for Go 1.20
 func StringerValuer(s fmt.Stringer) slog.LogValuer {
 	return stringerValuer{s}
 }
@@ -42,8 +40,6 @@ func responseToAttr(resp *http.Response) slog.Attr {
 
 // LoggedWriter stores information regarding the response.
 // This might be status code, amount of data written or header.
-//
-// EXPERIMENTAL: Will change to log/slog import after we drop support for Go 1.20
 type LoggedWriter interface {
 	http.ResponseWriter
 

--- a/config.go
+++ b/config.go
@@ -3,10 +3,10 @@ package logging
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/exp/slog"
 )
 
 type Config struct {
@@ -107,8 +107,6 @@ func (c *Config) parseFormatter() error {
 }
 
 // Slog constructs a slog.Logger with the Formatter and Level from config.
-//
-// EXPERIMENTAL: Will change to log/slog import after we drop support for Go 1.20
 func (c *Config) Slog() *slog.Logger {
 	logger := slog.Default()
 

--- a/context.go
+++ b/context.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"context"
 
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 type ctxKeyType struct{}
@@ -12,16 +12,12 @@ var ctxKey ctxKeyType
 
 // FromContext takes a Logger from the context, if it was
 // previously set by [ToContext]
-//
-// EXPERIMENTAL: Will change to log/slog import after we drop support for Go 1.20
 func FromContext(ctx context.Context) (logger *slog.Logger, ok bool) {
 	logger, ok = ctx.Value(ctxKey).(*slog.Logger)
 	return logger, ok
 }
 
 // ToContext sets a Logger to the context.
-//
-// EXPERIMENTAL: Will change to log/slog import after we drop support for Go 1.20
 func ToContext(ctx context.Context, logger *slog.Logger) context.Context {
 	return context.WithValue(ctx, ctxKey, logger)
 }

--- a/context_test.go
+++ b/context_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"log/slog"
+
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/exp/slog"
 )
 
 func TestContext(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,10 @@
 module github.com/zitadel/logging
 
-go 1.19
+go 1.21
 
 require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63
 	gopkg.in/yaml.v2 v2.2.8
 )
 

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63 h1:m64FZMko/V45gv0bNmrNYoDEq8U5YUhetc9cBWKS1TQ=
-golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63/go.mod h1:0v4NqG35kSWCMzLaMeX+IQrlSnVE/bqGSyC2cz/9Le8=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/http_client.go
+++ b/http_client.go
@@ -5,15 +5,13 @@ import (
 	"net/http"
 	"time"
 
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 type ClientLoggerOption func(*logRountTripper)
 
 // WithFallbackLogger uses the passed logger if none was
 // found in the context.
-//
-// EXPERIMENTAL: Will change to log/slog import after we drop support for Go 1.20
 func WithFallbackLogger(logger *slog.Logger) ClientLoggerOption {
 	return func(lrt *logRountTripper) {
 		lrt.fallback = logger

--- a/middleware.go
+++ b/middleware.go
@@ -4,15 +4,13 @@ import (
 	"net/http"
 	"time"
 
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 type MiddlewareOption func(*middleware)
 
 // WitLogger sets the passed logger with request attributes
 // into the Request's context.
-//
-// EXPERIMENTAL: Will change to log/slog import after we drop support for Go 1.20
 func WithLogger(logger *slog.Logger) MiddlewareOption {
 	return func(m *middleware) {
 		m.logger = logger

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -9,8 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"log/slog"
+
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/exp/slog"
 )
 
 func newTestLogger() (out *strings.Builder, logger *slog.Logger) {


### PR DESCRIPTION
This change adds Go 1.22 as a build target and drops support for Go 1.20 and older. The `golang.org/x/exp/slog` import is migrated to `log/slog`.

Slog has been part of the Go standard library since Go 1.21. Therefore we are dropping support for older Go versions. This is in line of our support policy of "the latest two Go versions".

Related to https://github.com/zitadel/oidc/issues/549